### PR TITLE
Fix dragging window from hidpi to non-hidpi crash

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -864,10 +864,6 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     _glfwPlatformGetWindowSize(window, &window->ns.width, &window->ns.height);
     _glfwPlatformGetFramebufferSize(window, &window->ns.fbWidth, &window->ns.fbHeight);
 
-    // layer required for EGL window surface creation
-    [window->ns.view setWantsLayer:YES];
-    window->ns.layer = [window->ns.view layer];
-
     return GLFW_TRUE;
 }
 
@@ -915,6 +911,9 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
         }
         else if (ctxconfig->source == GLFW_EGL_CONTEXT_API)
         {
+            // layer required for EGL window surface creation
+            [window->ns.view setWantsLayer:YES];
+            window->ns.layer = [window->ns.view layer];
             if (!_glfwInitEGL())
                 return GLFW_FALSE;
             if (!_glfwCreateContextEGL(window, ctxconfig, fbconfig))


### PR DESCRIPTION
It seems wantlayers has the sideeffect on dragging the window from one Monitor to another one while it's running under OpenGL to crash this PR solves this.
With angle and OpenGLES this will just continues to run fine.